### PR TITLE
Consertar aviso de Usuário Logado

### DIFF
--- a/app/src/main/java/com/dap/meau/LoginActivity.java
+++ b/app/src/main/java/com/dap/meau/LoginActivity.java
@@ -95,9 +95,11 @@ public class LoginActivity extends AppCompatActivity implements GoogleApiClient.
         super.onStart();
         // Check if user is signed in (non-null) and update UI accordingly.
         FirebaseUser currentUser = mAuth.getCurrentUser();
-        Toast.makeText(LoginActivity.this, "Usuário já está logado!",
-                Toast.LENGTH_LONG).show();
-        finish();
+        if(currentUser != null) {
+            Toast.makeText(LoginActivity.this, "Usuário já está logado!",
+                    Toast.LENGTH_LONG).show();
+            finish();
+        }
     }
 
     private void signIn() {


### PR DESCRIPTION
O aviso aparecia mesmo que não tivesse uma sessão ativa, e impedia o login.