### PR TITLE
Esconder animais indisponíveis da lista de adoção

### DIFF
--- a/app/src/main/java/com/dap/meau/ui/main/MainFragment.java
+++ b/app/src/main/java/com/dap/meau/ui/main/MainFragment.java
@@ -77,7 +77,7 @@ public class MainFragment extends Fragment {
                     petModel = snapshot.getValue(PetModel.class);
                     uuid = petModel.getUserUid();
 
-                    if (!uid.matches(uuid) && !petModel.isAvailable()) mList.add(petModel);
+                    if (!uid.matches(uuid) && petModel.isAvailable()) mList.add(petModel);
                 }
                 mAdapter.setList(mList);
             }

--- a/app/src/main/java/com/dap/meau/ui/main/MainFragment.java
+++ b/app/src/main/java/com/dap/meau/ui/main/MainFragment.java
@@ -77,7 +77,7 @@ public class MainFragment extends Fragment {
                     petModel = snapshot.getValue(PetModel.class);
                     uuid = petModel.getUserUid();
 
-                    if (!uid.matches(uuid)) mList.add(petModel);
+                    if (!uid.matches(uuid) && !petModel.isAvailable()) mList.add(petModel);
                 }
                 mAdapter.setList(mList);
             }


### PR DESCRIPTION
Checa se o pet está marcado como disponível antes de exibi-lo na lista.