### PR TITLE
Definir animal como indisponível na conclusão de uma adoção

### DIFF
--- a/app/src/main/java/com/dap/meau/Adapter/AcceptActivityAdapter.java
+++ b/app/src/main/java/com/dap/meau/Adapter/AcceptActivityAdapter.java
@@ -58,6 +58,7 @@ public class AcceptActivityAdapter extends RecyclerView.Adapter<DefaultUserSimpl
                             @Override
                             public void onClick(DialogInterface dialogInterface, int i) {
                                 mPetModel.setUserUid(mList.get(position).getUid());
+                                mPetModel.setAvailable(false);
                                 PetDatabaseHelper.updatePet(mPetModel, new OnSuccessListener() {
                                     @Override
                                     public void onSuccess(Object o) {


### PR DESCRIPTION
Atualiza AcceptActivityAdapter.java com mPetModel.setAvailable(false), para que o animal não fique mais disponível depois de adotado.