### PR TITLE
Retornar o usuário para "Meus pets" após uma adoção

### DIFF
--- a/app/src/main/java/com/dap/meau/Adapter/AcceptActivityAdapter.java
+++ b/app/src/main/java/com/dap/meau/Adapter/AcceptActivityAdapter.java
@@ -83,6 +83,7 @@ public class AcceptActivityAdapter extends RecyclerView.Adapter<DefaultUserSimpl
                                                 }
 
                                                 Toast.makeText(mActivity, "Adoção realizada com sucesso!", Toast.LENGTH_SHORT).show();
+                                                mActivity.setResult(Activity.RESULT_OK);
                                                 mActivity.finish();
                                             }
 

--- a/app/src/main/java/com/dap/meau/PerfilAnimal.java
+++ b/app/src/main/java/com/dap/meau/PerfilAnimal.java
@@ -2,7 +2,9 @@ package com.dap.meau;
 
 import android.content.DialogInterface;
 import android.content.Intent;
+import android.preference.PreferenceManager;
 import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
 import android.support.v4.app.NotificationManagerCompat;
 import android.support.v7.app.ActionBar;
 import android.support.v7.app.AlertDialog;
@@ -44,6 +46,7 @@ public class PerfilAnimal extends AppCompatActivity {
     TextView mTxtName, mTxtGender, mTxtPostage, mTxtAge, mTxtCity, mTxtCastrated, mTxtDewormed, mTxtVaccinated, mTxtDisease, mTxtTemperament, mTxtRequiriments, mTxtAbout, mTxtAboutTitle;
     Button mButton, mBtnAvail, mBtnInterest;
     PetModel mPetModel;
+    final int ACCEPT_ACTIVITY = 1;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -221,7 +224,7 @@ public class PerfilAnimal extends AppCompatActivity {
                     Bundle b = new Bundle();
                     b.putSerializable(PetModel.class.getName(), mPetModel);
                     intent.putExtras(b);
-                    startActivity(intent);
+                    startActivityForResult(intent, ACCEPT_ACTIVITY);
                 }
             }
         });
@@ -253,5 +256,14 @@ public class PerfilAnimal extends AppCompatActivity {
                         .setNegativeButton(R.string.Noo, null).show();
             }
         });
+    }
+
+    @Override
+    protected void onActivityResult(int requestCode, int resultCode, @Nullable Intent data) {
+        super.onActivityResult(requestCode, resultCode, data);
+
+        if(requestCode == ACCEPT_ACTIVITY && resultCode == RESULT_OK) {
+            finish();
+        }
     }
 }


### PR DESCRIPTION
Previne que o usuário tenha controle sobre um animal que já não é mais dele após uma adoção, removendo a tela de perfil desse animal da pilha de atividades.